### PR TITLE
Fix declare() with dash and extra

### DIFF
--- a/lib/SemVer.pm
+++ b/lib/SemVer.pm
@@ -83,7 +83,7 @@ sub declare {
     return $class->new($ival) if Scalar::Util::isvstring($ival)
         or eval { $ival->isa('version') };
 
-    (my $v = $ival) =~ s/^v?$STRICT_DOTTED_INTEGER_VERSION(?:($DASH_SEPARATOR)($OPTIONAL_EXTRA_PART))[[:space:]]*$//;
+    (my $v = $ival) =~ s/($DASH_SEPARATOR)($OPTIONAL_EXTRA_PART)$//;
     my $dash  = $1;
     my $extra = $2;
     $v += 0 if $v =~ s/_//g; # ignore underscores.
@@ -99,7 +99,7 @@ sub parse {
     return $class->new($ival) if Scalar::Util::isvstring($ival)
         or eval { $ival->isa('version') };
 
-    (my $v = $ival) =~ s/^v?$STRICT_DOTTED_INTEGER_VERSION(?:($DASH_SEPARATOR)($OPTIONAL_EXTRA_PART))[[:space:]]*$//;
+    (my $v = $ival) =~ s/($DASH_SEPARATOR)($OPTIONAL_EXTRA_PART)$//;
     my $dash  = $1;
     my $extra = $2;
     $v += 0 if $v =~ s/_//g; # ignore underscores.

--- a/t/base.t
+++ b/t/base.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 610;
+use Test::More tests => 699;
 #use Test::More 'no_plan';
 
 use FindBin qw($Bin);
@@ -146,6 +146,32 @@ for my $spec (
     cmp_ok $l, 'ge', $r, "$l ge $r";
 }
 
+# Test equivalents with declare
+for my $spec (
+    [ '1.2.0',                '1.2' ],
+    [ '0.0.0',                '0' ],
+    [ '999.888.7777-alpha.3', '999.888.7777-alpha.3' ],
+    [ '0.1.2-beta3',          '0.1.2-beta3' ],
+    [ '1.0.0-rc-1',           '1.0.0-RC-1' ],
+) {
+    my $l = $CLASS->declare($spec->[0]);
+    my $r = $CLASS->declare($spec->[1]);
+    is $l->vcmp($r), 0, "$l->vcmp($r) == 0";
+    is $l <=> $r, 0, "$l <=> $r == 0";
+    is $r <=> $l, 0, "$r <=> $l == 0";
+    cmp_ok $l, '==', $r, "$l == $r";
+    cmp_ok $l, '==', $r, "$l == $r";
+    cmp_ok $l, '<=', $r, "$l <= $r";
+    cmp_ok $l, '>=', $r, "$l >= $r";
+    is $l cmp $r, 0, "$l cmp $r == 0";
+    is $r cmp $l, 0, "$r cmp $l == 0";
+    cmp_ok $l, 'eq', $r, "$l eq $r";
+    cmp_ok $l, 'eq', $r, "$l eq $r";
+    cmp_ok $l, 'le', $r, "$l le $r";
+    cmp_ok $l, 'ge', $r, "$l ge $r";
+}
+
+
 # Test not equal.
 for my $spec (
     ['1.2.2',   '1.2.3'],
@@ -159,6 +185,24 @@ for my $spec (
 ) {
     my $l = $CLASS->new($spec->[0]);
     my $r = $CLASS->new($spec->[1]);
+    cmp_ok $l->vcmp($r), '!=', 0, "$l->vcmp($r) != 0";
+    cmp_ok $l, '!=', $r, "$l != $r";
+    cmp_ok $l, 'ne', $r, "$l ne $r";
+}
+
+# Test not equal with declare.
+for my $spec (
+    ['1.2.2',   '1.2.3'],
+    ['0.0.1',   '1.0.0'],
+    ['1.0.1',   '1.1.0'],
+    ['1.1.1',   '1.1.0'],
+    ['1.2.3-b', '1.2.3'],
+    ['1.2.3',   '1.2.3-b'],
+    ['1.2.3-a', '1.2.3-b'],
+    ['1.2.3-aaaaaaa1', '1.2.3-aaaaaaa2'],
+) {
+    my $l = $CLASS->declare($spec->[0]);
+    my $r = $CLASS->declare($spec->[1]);
     cmp_ok $l->vcmp($r), '!=', 0, "$l->vcmp($r) != 0";
     cmp_ok $l, '!=', $r, "$l != $r";
     cmp_ok $l, 'ne', $r, "$l ne $r";


### PR DESCRIPTION
SemVer has a bug introduced in 8781c0d987f2abde08293a7ea127b68167bc9cb6:

````shell
$ perl -MSemVer -le'print SemVer->declare("3.1.0")->normal'
3.1.0
$ perl -MSemVer -le'print SemVer->declare("3.1.0-something")->normal'
Invalid version format (version required) at .../SemVer.pm line 90.
````

What happens in the second case ("3.1.0-something") is that this regular
expression matches:

````perl
  (my $v = $ival) =~ s/^v?$STRICT_DOTTED_INTEGER_VERSION(?:($DASH_SEPARATOR)($OPTIONAL_EXTRA_PART))[[:space:]]*$//;
````

So the entire version string is replaced by nothing, and that is the
value that $v gets. All other cases (such as "3.1", or "3.1.0") don't
match, and so the replacement never happens.

This empty $v is then passed on to version->declare, which complains
that the version is required.

It seems the full regexp was added hoping to be a validation step for
strict semantic versions in declare() and parse(). Unfortunately, this
wasn't working (as explained above), and in fact, that is not the
desired behaviour for these functions. From the docs for declare():
"This is the most flexible way to declare versions. Consider using it to
normalize version strings." With that in mind, the input has to allow
"not normal" version strings.

This patch restores the old behaviour, fixing usage of declare() and
parse(). I'm not super comfortable with how parse() is supposed to work,
so I didn't add any tests for it. But I did add tests for declare().